### PR TITLE
Fix syntax error in cice_runmod.F90 by removing continuation

### DIFF
--- a/drivers/access/CICE_RunMod.F90
+++ b/drivers/access/CICE_RunMod.F90
@@ -896,7 +896,7 @@
          i,j         , & ! horizontal indices
          ilo,ihi,jlo,jhi ! beginning and end of physical domain
 
-      real (kind=dbl_kind) :: & cszn
+      real (kind=dbl_kind) :: cszn ! counter for history averaging
 
       call ice_timer_start(timer_column)
 


### PR DESCRIPTION
Closes #5 for the `access-esm1.5` branch. 

The code change has been tested by building the `cice4` Spack package using the `5-syntax-error-in-cice_runmod-f90` branch instead of `access-esm1.5`, and the package builds successfully using both `%intel@19.0.5.281` and `%intel@2021.10.0`.
