### PR TITLE
Properly produce an error from ice_exit

### DIFF
--- a/mpi/ice_exit.F90
+++ b/mpi/ice_exit.F90
@@ -66,6 +66,8 @@
 !EOP
 !
       integer (int_kind) :: ierr ! MPI error flag
+      ! MPI error code, default to non-zero error
+      integer (int_kind) :: errorcode = 1
 
 #if (defined CCSM) || (defined SEQ_MCT)
       call shr_sys_abort(error_message)
@@ -75,7 +77,7 @@
       write (ice_stderr,*) error_message
       call flush_fileunit(ice_stderr)
 
-      call MPI_ABORT(MPI_COMM_WORLD, ierr)
+      call MPI_ABORT(MPI_COMM_WORLD, errorcode, ierr)
       stop
 #endif
 

--- a/mpi/ice_exit.F90
+++ b/mpi/ice_exit.F90
@@ -65,9 +65,9 @@
 !
 !EOP
 !
-      integer (int_kind) :: ierr ! MPI error flag
-      ! MPI error code, default to non-zero error
-      integer (int_kind) :: errorcode = 1
+      integer (int_kind) :: &
+            ierr,          & ! MPI error flag
+            error_code = 128 ! MPI error code, default to non-zero error
 
 #if (defined CCSM) || (defined SEQ_MCT)
       call shr_sys_abort(error_message)
@@ -77,7 +77,7 @@
       write (ice_stderr,*) error_message
       call flush_fileunit(ice_stderr)
 
-      call MPI_ABORT(MPI_COMM_WORLD, errorcode, ierr)
+      call MPI_ABORT(MPI_COMM_WORLD, error_code, ierr)
       stop
 #endif
 

--- a/source/ice_fileunits.F90
+++ b/source/ice_fileunits.F90
@@ -71,7 +71,7 @@
       integer (kind=int_kind), parameter :: &
          ice_stdin  =  5, & ! reserved unit for standard input
          ice_stdout =  6, & ! reserved unit for standard output
-         ice_stderr =  6    ! reserved unit for standard error
+         ice_stderr =  0    ! reserved unit for standard error
 !EOP
 !BOC
       integer (kind=int_kind), parameter :: &


### PR DESCRIPTION
First part of work for #13. Adding the traceback calls will be deferred while compilation issues with the preprocessor directives are being worked out. 

This PR adds an error code to the `mpi_abbort` call in `abort_ice`, so that errors can be properly interpreted by payu. It also changes the file unit for `stderr`, so that error messages are not written to `stdout`. These changes are based on [what was done in CICE5](https://github.com/ACCESS-NRI/cice5/blob/cice_gsi8.1/mpi/ice_exit.F90).


Results from testing:

I added some errors to `ice_nml` in the cice namelist, which will [trigger `abort_ice`](https://github.com/ACCESS-NRI/cice4/blob/e7549ebd2044690a432cc67c1317c81cb194b750/source/ice_init.F90#L335).

With the changes, we get the following in the error logs:
```
 ice: error reading namelist
 ice: error reading namelist
 ice: error reading namelist
 ice: error reading namelist
 ice: error reading namelist
 ice: error reading namelist
 ice: error reading namelist
 ice: error reading namelist
 ice: error reading namelist
 ice: error reading namelist
 ice: error reading namelist
 ice: error reading namelist
--------------------------------------------------------------------------
MPI_ABORT was invoked on rank 428 in communicator MPI_COMM_WORLD
with errorcode 1.
```

Without the changes, payu thinks that no error has occurred and tries to  archive non-existent output/restarts, resulting in 

```
archive
├── pbs_logs
└── restart000
    └── atmosphere
        └── um.res.yaml
```


