### PR TITLE
Properly produce an error from ice_exit (#14)

### DIFF
--- a/mpi/ice_exit.F90
+++ b/mpi/ice_exit.F90
@@ -65,7 +65,9 @@
 !
 !EOP
 !
-      integer (int_kind) :: ierr ! MPI error flag
+      integer (int_kind) :: &
+            ierr,          & ! MPI error flag
+            error_code = 128 ! MPI error code, default to non-zero error
 
 #if (defined CCSM) || (defined SEQ_MCT)
       call shr_sys_abort(error_message)
@@ -75,7 +77,7 @@
       write (ice_stderr,*) error_message
       call flush_fileunit(ice_stderr)
 
-      call MPI_ABORT(MPI_COMM_WORLD, ierr)
+      call MPI_ABORT(MPI_COMM_WORLD, error_code, ierr)
       stop
 #endif
 

--- a/source/ice_fileunits.F90
+++ b/source/ice_fileunits.F90
@@ -71,7 +71,7 @@
       integer (kind=int_kind), parameter :: &
          ice_stdin  =  5, & ! reserved unit for standard input
          ice_stdout =  6, & ! reserved unit for standard output
-         ice_stderr =  6    ! reserved unit for standard error
+         ice_stderr =  0    ! reserved unit for standard error
 !EOP
 !BOC
       integer (kind=int_kind), parameter :: &


### PR DESCRIPTION
PR https://github.com/ACCESS-NRI/cice4/pull/14 adds small error handling changes to CICE so that model crashes are correctly handled by payu.

This PR cherry picks the same changes to the same branch used by ESM1.6